### PR TITLE
Move swift build to SourceKitService.synchronizeRepository()

### DIFF
--- a/SourceKitService/LanguageServer.swift
+++ b/SourceKitService/LanguageServer.swift
@@ -42,18 +42,6 @@ final class LanguageServer {
 
         let rootURI = Workspace.documentRoot(resource: resource, slug: slug)
 
-        let buildProcess = Process()
-        buildProcess.launchPath = "/usr/bin/xcrun"
-        buildProcess.arguments = ["swift", "build"]
-        buildProcess.currentDirectoryURL = rootURI
-
-        let stdout = Pipe()
-        buildProcess.standardOutput = stdout
-        let stderr = Pipe()
-        buildProcess.standardError = stderr
-
-        buildProcess.launch()
-
         connection.start(receiveHandler: Client())
 
         serverProcess.launchPath = serverPath


### PR DESCRIPTION
Hi,

Repo looking really good now with your recent changes. I’m filing the PR mostly because I’d like to provide a little more feedback of what might be issues I'm seeing since I added in `swift build` for code references. It may not be directly related to this and I don’t have a super powerful Mac but I’m finding the load of pages showing individual source files happens much more slowly with the plugin enabled. Is there something that could be deferred/run in the background? I don’t know enough about how the plugin works to benchmark and see how this could be avoided. 

I’ve been testing with:

A single source repo
https://github.com/johnno1962/SwiftRegex5/blob/master/Sources/TupleRegex.swift
A bit more involved:
https://github.com/johnno1962/GitInfo/blob/master/Sources/GitInfo.swift
More involved again:
https://github.com/johnno1962/siteify/blob/master/siteify/Siteify.swift

I’m also finding for large projects, the symbol browser does not always come up when you visit a repo for the first time and it has to be fetched and built and you can have to refresh the page. It looked to me like this was a network http request timeout on port 50000 when the project took more than 30 seconds to build (according to the TCP syslogs) but I may have been seeing things. Perhaps, the swift build would be asynchronous and references requests not be cached so they have a chance to refresh when the data turns up. I’ll keep looking at it but I’m a bit at sea how the plugin actually works TBH.

Keep up the good work — This is a very exciting development! Let’s hope @github takes the hint.

Edit: If you defer the setup of the mouseover events, the page appears to load more quickly:
```
diff --git a/SafariExtension/js/bundle.js b/SafariExtension/js/bundle.js
index d23656e..fdd5918 100644
--- a/SafariExtension/js/bundle.js
+++ b/SafariExtension/js/bundle.js
@@ -388,6 +388,7 @@ const activate = () => {
     return;
   }

+  setTimeout(function() {
   const lines = document.querySelectorAll(".blob-code");
   const text = readLines(lines);

@@ -455,6 +456,7 @@ const activate = () => {
       handleResponse(event, parsedUrl);
     });
   }
+  }, 2000);
 };

 (() => {
```
Moving the `setTimeout` around you can get a measure where the time goes.