### PR TITLE
Logging of background builds for references

### DIFF
--- a/SafariExtension/SafariExtensionHandler.swift
+++ b/SafariExtension/SafariExtensionHandler.swift
@@ -46,6 +46,15 @@ final class SafariExtensionHandler: SFSafariExtensionHandler {
                     }
                 }
             }
+        case "buildProgress":
+          guard let userInfo = userInfo,
+              let resource = userInfo["resource"] as? String
+              else { return }
+          self.service.fetchBuildProgress(resource: resource) { [weak self] (successfully, response) in
+            guard let _ = self, let value = response["value"] else { return }
+            page.dispatchMessageToScript(withName: "response", userInfo: [
+              "request": "buildProgress", "result": "success", "value": value])
+          }
         case "hover":
             guard let userInfo = userInfo,
                 let resource = userInfo["resource"] as? String,

--- a/SafariExtension/js/bundle.js
+++ b/SafariExtension/js/bundle.js
@@ -64,6 +64,12 @@ function dispatchMessage(messageName, userInfo) {
 
 var progressPopover, didOpenInfo;
 
+function pollBuildProgress(info) {
+  dispatchMessage("buildProgress", info);
+  if (progressPopover)
+    setTimeout(() => { pollBuildProgress(info); }, 1000);
+}
+
 function handleResponse(event, parsedUrl) {
   switch (event.name) {
     case "response":
@@ -83,16 +89,17 @@ function handleResponse(event, parsedUrl) {
 
               symbolNavigator(symbols, parsedUrl.href).show();
               progressPopover = progressNavigator(parsedUrl.href);
-              progressPopover.show();
-              dispatchMessage("buildProgress", {
-                              resource: `${parsedUrl.protocol}://${parsedUrl.resource}/${parsedUrl.full_name}/${parsedUrl}`
-                              });
+              pollBuildProgress({
+                resource: `${parsedUrl.protocol}://${parsedUrl.resource}/${parsedUrl.full_name}/${parsedUrl}`
+              });
             }
           })();
           break;
         case "buildProgress":
           (() => {
            const value = event.message.value;
+           if (value.text)
+             progressPopover.show();
            const progressPre = document.getElementById("--sourcekit-for-safari_progress-navigation");
            if (progressPre) {
              progressPre.innerHTML = value.text;
@@ -110,6 +117,7 @@ function handleResponse(event, parsedUrl) {
              dispatchMessage("didOpen", didOpenInfo);
              setTimeout(() => {
                progressPopover.hide();
+               progressPopover = null;
              }, 5000);
            }
           })();

--- a/SafariExtension/js/index.js
+++ b/SafariExtension/js/index.js
@@ -14,7 +14,7 @@ marked.setOptions({
 
 const { readLines, highlightReferences } = require("./parser");
 const { setupQuickHelp, setupQuickHelpContent } = require("./quickhelp");
-const { symbolNavigator } = require("./symbol_navigator");
+const { symbolNavigator, progressNavigator } = require("./symbol_navigator");
 const { normalizedLocation } = require("./helper");
 
 if (typeof chrome !== "undefined") {
@@ -52,11 +52,15 @@ function dispatchMessage(messageName, userInfo) {
   }
 }
 
+var progressPopover, didOpenInfo;
+
 function handleResponse(event, parsedUrl) {
   switch (event.name) {
     case "response":
       switch (event.message.request) {
         case "documentSymbol":
+          if (progressPopover)
+            break;
           (() => {
             const value = event.message.value;
             if (value && Array.isArray(value)) {
@@ -68,7 +72,36 @@ function handleResponse(event, parsedUrl) {
               }
 
               symbolNavigator(symbols, parsedUrl.href).show();
+              progressPopover = progressNavigator(parsedUrl.href);
+              progressPopover.show();
+              dispatchMessage("buildProgress", {
+                              resource: `${parsedUrl.protocol}://${parsedUrl.resource}/${parsedUrl.full_name}/${parsedUrl}`
+                              });
             }
+          })();
+          break;
+        case "buildProgress":
+          (() => {
+           const value = event.message.value;
+           const progressPre = document.getElementById("--sourcekit-for-safari_progress-navigation");
+           if (progressPre) {
+             progressPre.innerHTML = value.text;
+             if (value.complete)
+                progressPre.innerHTML += value.failed ?
+                    "<p><p><b style='color: red'>Build failed</b>" :
+                    "<p><p><b style='color: green'>Build complete</b>";
+             progressPre.parentElement.scrollTop = progressPre.parentElement.scrollHeight;
+           }
+           if (!value.complete)
+             dispatchMessage("buildProgress", {
+                             resource: `${parsedUrl.protocol}://${parsedUrl.resource}/${parsedUrl.full_name}/${parsedUrl}`
+                             });
+           else if (!value.failed) {
+             dispatchMessage("didOpen", didOpenInfo);
+             setTimeout(() => {
+               progressPopover.hide();
+             }, 5000);
+           }
           })();
           break;
         case "hover":
@@ -385,7 +418,7 @@ const activate = () => {
   const lines = document.querySelectorAll(".blob-code");
   const text = readLines(lines);
 
-  dispatchMessage("didOpen", {
+  dispatchMessage("didOpen", didOpenInfo = {
     resource: parsedUrl.resource,
     slug: parsedUrl.full_name,
     filepath: parsedUrl.filepath,

--- a/SafariExtension/js/symbol_navigator.js
+++ b/SafariExtension/js/symbol_navigator.js
@@ -91,3 +91,69 @@ function symbolNavigator(documentSymbols, documentUrl) {
 }
 
 exports.symbolNavigator = symbolNavigator;
+
+let progress = null;
+
+function progressNavigator(documentUrl) {
+  if (progress) {
+    progress.destroy();
+    progress = null;
+  }
+
+  const navigationContainer = document.createElement("div");
+  navigationContainer.classList.add(
+    "--sourcekit-for-safari_symbol-navigation",
+    "overflow-auto"
+  );
+
+  const navigationList = document.createElement("div");
+  navigationList.classList.add("list-group", "col-12");
+
+  const blobCodeInner = document.querySelector(".blob-code-inner");
+  const style = getComputedStyle(blobCodeInner);
+  navigationList.style.cssText = `font-size: ${style.fontSize};`;
+
+  navigationContainer.appendChild(navigationList);
+
+  const navigationHeader = document.createElement("a");
+  navigationHeader.href = "#--sourcekit-for-safari_progress-navigation-items";
+  navigationHeader.classList.add("list-group-item", "list-group-item-action");
+  navigationHeader.dataset.toggle = "collapse";
+  const chevronImage = (() => {
+    if (typeof safari !== "undefined") {
+      return `${safari.extension.baseURI}chevron.down`;
+    } else {
+      return chrome.extension.getURL(`images/chevron.down`);
+    }
+  })();
+  navigationHeader.innerHTML = `Build Progress <img srcset="${chevronImage}.png, ${chevronImage}@2x.png 2x, ${chevronImage}@3x.png 3x" width="15" height="8" align="center" />`;
+  navigationHeader.style.cssText = `font-size: ${style.fontSize}; font-weight: bold;`;
+  navigationList.appendChild(navigationHeader);
+
+  const navigationItemContainer = document.createElement("div");
+  navigationItemContainer.classList.add("collapse", "show");
+  navigationItemContainer.id = "--sourcekit-for-safari_progress-navigation-items";
+  navigationItemContainer.style.cssText = `overflow-y: scroll; max-height: 30vh;`;
+  navigationList.appendChild(navigationItemContainer);
+
+  const navigationProgress = document.createElement("pre");
+  navigationProgress.id = "--sourcekit-for-safari_progress-navigation";
+  navigationProgress.style.cssText = `font-size: 6pt;`;
+  navigationItemContainer.appendChild(navigationProgress);
+
+  progress = tippy(document.querySelector(".blob-wrapper"), {
+    content: navigationContainer,
+    interactive: true,
+    arrow: false,
+    animation: false,
+    duration: 0,
+    placement: "right-start",
+    offset: [0, 4],
+    theme: "light-border",
+    trigger: "manual",
+    hideOnClick: false
+  });
+  return progress;
+}
+
+exports.progressNavigator = progressNavigator;

--- a/Shared/SourceKitServiceProxy.swift
+++ b/Shared/SourceKitServiceProxy.swift
@@ -187,6 +187,21 @@ final class SourceKitServiceProxy {
         }
     }
 
+    func fetchBuildProgress(resource: String, completion: @escaping (Bool, [String: Any]) -> Void) {
+        let connection = self.connection
+        let context = self.context
+
+        queue.async {
+            connection.resume()
+            defer { connection.suspend() }
+            guard let service = connection.remoteObjectProxy as? SourceKitServiceProtocol else { return }
+
+            service.fetchBuildProgress(context: context, resource: resource) { (successfully, response) in
+                completion(successfully, response)
+            }
+        }
+    }
+
     func deleteLocalRepository(_ repository: URL, completion: @escaping (Bool, URL?) -> Void) {
         let connection = self.connection
 

--- a/SourceKitService/ServerRegistry.swift
+++ b/SourceKitService/ServerRegistry.swift
@@ -21,6 +21,13 @@ final class ServerRegistry {
         servers.removeValue(forKey: makeKey(host: resource, slug: slug))
     }
 
+    func removeAll() {
+      for (_, server) in servers {
+        server.sendExitNotification()
+      }
+      servers.removeAll()
+    }
+
     private func makeKey(host: String, slug: String) -> URL {
         URL(
             string: host.replacingOccurrences(of: "https://", with: "")

--- a/SourceKitService/SourceKitService.swift
+++ b/SourceKitService/SourceKitService.swift
@@ -185,10 +185,6 @@ class SourceKitService: NSObject, SourceKitServiceProtocol {
 
         if FileManager().fileExists(atPath: directory.path) && !force {
             reply(true, nil)
-            DispatchQueue.global().asyncAfter(deadline: .now() + 3.0) {
-              self.progressLog = ""
-              self.log("", complete: true)
-            }
             return
         }
 

--- a/SourceKitService/SourceKitService.swift
+++ b/SourceKitService/SourceKitService.swift
@@ -3,6 +3,10 @@ import LanguageServerProtocol
 
 @objc
 class SourceKitService: NSObject, SourceKitServiceProtocol {
+    var progressLog = ""
+    var progressCallback: BuildProgressCallback?
+    let progressQueue = DispatchQueue(label: "progressQueue")
+
     func sendInitalizeRequest(context: [String : String], resource: String, slug: String, reply: @escaping (Bool, [String : Any]) -> Void) {
         let server = ServerRegistry.shared.get(resource: resource, slug: slug)
 
@@ -163,6 +167,14 @@ class SourceKitService: NSObject, SourceKitServiceProtocol {
     }
 
     func synchronizeRepository(context: [String : String], repository remoteRepository: URL, ignoreLastUpdate force: Bool, reply: @escaping (Bool, URL?) -> Void) {
+      progressLog = ""
+      DispatchQueue.global().async {
+        self.asynchronizeRepository(context: context, repository: remoteRepository, ignoreLastUpdate: force, reply: reply)
+      }
+    }
+
+    func asynchronizeRepository(context: [String : String], repository remoteRepository: URL, ignoreLastUpdate force: Bool, reply: @escaping (Bool, URL?) -> Void) {
+
         guard let host = remoteRepository.host else { return }
 
         let groupContainer = Workspace.root
@@ -173,6 +185,10 @@ class SourceKitService: NSObject, SourceKitServiceProtocol {
 
         if FileManager().fileExists(atPath: directory.path) && !force {
             reply(true, nil)
+            DispatchQueue.global().asyncAfter(deadline: .now() + 3.0) {
+              self.progressLog = ""
+              self.log("", complete: true)
+            }
             return
         }
 
@@ -191,13 +207,7 @@ class SourceKitService: NSObject, SourceKitServiceProtocol {
                     "HEAD",
                 ]
 
-                let standardOutput = Pipe()
-                process.standardOutput = standardOutput
-                let standardError = Pipe()
-                process.standardError = standardError
-
-                process.launch()
-                process.waitUntilExit()
+                launchAndLog(process: process)
 
                 swiftBuild(inDirectory: localDirectory)
 
@@ -229,13 +239,7 @@ class SourceKitService: NSObject, SourceKitServiceProtocol {
                     localDirectory.path,
                 ]
 
-                let standardOutput = Pipe()
-                process.standardOutput = standardOutput
-                let standardError = Pipe()
-                process.standardError = standardError
-
-                process.launch()
-                process.waitUntilExit()
+                launchAndLog(process: process)
 
                 swiftBuild(inDirectory: localDirectory)
 
@@ -248,14 +252,56 @@ class SourceKitService: NSObject, SourceKitServiceProtocol {
         }
     }
 
+    func launchAndLog(process: Process) {
+        process.standardOutput = logPipe(stderr: false)
+        process.standardError = logPipe(stderr: true)
+
+        process.launch()
+        process.waitUntilExit()
+    }
+
     func swiftBuild(inDirectory: URL) {
+        log("\n<b>Building package...</b>\n")
+
         let process = Process()
         process.currentDirectoryURL = inDirectory
         process.launchPath = "/usr/bin/xcrun"
         process.arguments = ["swift", "build"]
 
-        process.launch()
-        process.waitUntilExit()
+        launchAndLog(process: process);
+
+        self.log("", complete: true,
+                 failed: process.terminationStatus != EXIT_SUCCESS)
+        ServerRegistry.shared.removeAll()
+    }
+
+    func logPipe(stderr: Bool) -> Pipe {
+      let pipe = Pipe()
+      DispatchQueue.global().async {
+        while let result = String(data: pipe
+          .fileHandleForReading.availableData, encoding: .utf8),
+          result.count != 0 {
+            self.log(stderr ? "<b>\(result)</b>" : result)
+        }
+      }
+      return pipe
+    }
+
+  func log(_ msg: String, complete: Bool = false, failed: Bool = false) {
+      progressQueue.async {
+        self.progressLog += msg
+        if let callback = self.progressCallback {
+          callback(true, ["result": "success", "value": [
+            "complete": complete, "failed": failed, "text": self.progressLog]])
+          self.progressCallback = nil
+        }
+      }
+    }
+
+    func fetchBuildProgress(context: [String : String], resource: String, reply: @escaping BuildProgressCallback) {
+      progressQueue.async {
+        self.progressCallback = reply
+      }
     }
 
     func deleteLocalRepository(_ localRepository: URL, reply: @escaping (Bool, URL?) -> Void) {

--- a/SourceKitService/SourceKitServiceProtocol.h
+++ b/SourceKitService/SourceKitServiceProtocol.h
@@ -91,6 +91,12 @@ NS_SWIFT_NAME(defaultSDKPath(for:reply:));
                         reply:(void (^)(BOOL successfully, NSURL * _Nullable localPath))reply
 NS_SWIFT_NAME(synchronizeRepository(context:repository:ignoreLastUpdate:reply:));
 
+typedef void (^BuildProgressCallback)(BOOL successfully, NSDictionary<NSString *, id> * progress);
+- (void)fetchBuildProgress:(NSDictionary<NSString *, NSString *> *)context
+        resource:(NSString *)resource
+           reply:(BuildProgressCallback)reply
+NS_SWIFT_NAME(fetchBuildProgress(context:resource:reply:));
+
 - (void)deleteLocalRepository:(NSURL *)repository reply:(void (^)(BOOL successfully, NSURL * _Nullable localPath))reply
 NS_SWIFT_NAME(deleteLocalRepository(_:reply:));
 


### PR DESCRIPTION
Hi, a proof of concept where the plugin displays a log of the background build as it is being performed to realise the references information. It’s a bit kludgey as it need to restart the LSP server process to have it refetch the index db when it is finished by messaging “didOpen” again. There is still the problem where, for larger projects, the browser messaging times out after 30 seconds and you have to refresh the page so try [this file](https://github.com/johnno1962/GitInfo/blob/master/Sources/GitInfo.swift) to see what it looks like when it works.

<img width="359" alt="image" src="https://user-images.githubusercontent.com/1786033/79568374-071d8600-80b6-11ea-824a-1870e16643ab.png">
